### PR TITLE
Switch LhUser verification to accountType enum

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -31,7 +31,7 @@ public struct UserManager: UserManageable {
     private func createLhUser() async throws -> (LhUser, CKRecord) {
         let (systemUser, systemUserRecord) = try await getSystemUser()
         guard systemUser.lhUserRecordName == nil else { throw CloudKitError.lhUserAlreadyExistsForSystemUser }
-        let user = LhUser(username: "user-\(Date.now.timeIntervalSince1970.description)-\(randomString(length: 8))", followingLhUserRecordNames: [], image: nil, isVerified: false)
+        let user = LhUser(username: "user-\(Date.now.timeIntervalSince1970.description)-\(randomString(length: 8))", followingLhUserRecordNames: [], image: nil, accountType: nil)
         let lhUserRecord = try await ck.save(record: user.record, db: .pubDb)
         systemUserRecord[User.UserRecordKeys.lhUserRecordName.rawValue] = lhUserRecord.recordID.recordName
         let _ = try await ck.save(record: systemUserRecord, db: .pubDb)
@@ -106,7 +106,7 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: Array(newFollowing),
             image: selfLhUser.image,
-            isVerified: selfLhUser.isVerified
+            accountType: selfLhUser.accountType
         )
         return try await updateSelfLhUser(with: newUser)
     }
@@ -117,7 +117,7 @@ public struct UserManager: UserManageable {
             username: username,
             followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
             image: selfLhUser.image,
-            isVerified: selfLhUser.isVerified
+            accountType: selfLhUser.accountType
         )
 
         return try await updateSelfLhUser(with: newUser)
@@ -130,7 +130,7 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
             image: asset,
-            isVerified: selfLhUser.isVerified
+            accountType: selfLhUser.accountType
         )
 
         return try await updateSelfLhUser(with: newUser)
@@ -149,7 +149,7 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: Array(newFollowing),
             image: selfLhUser.image,
-            isVerified: selfLhUser.isVerified
+            accountType: selfLhUser.accountType
         )
         return try await updateSelfLhUser(with: newUser)
     }

--- a/Sources/lhCloudKit/Models/LhUser.swift
+++ b/Sources/lhCloudKit/Models/LhUser.swift
@@ -12,20 +12,25 @@ public struct LhUser {
     public let username: String
     public let followingLhUserRecordNames: [String]
     public let image: CKAsset?
-    public let isVerified: Bool
+    public let accountType: AccountType?
+
+    public enum AccountType: String {
+        case verifiedUser
+        case verifiedArtist
+    }
 
     public init(
         recordId: CKRecord.ID? = nil,
         username: String,
         followingLhUserRecordNames: [String],
         image: CKAsset?,
-        isVerified: Bool
+        accountType: AccountType?
     ) {
         self.recordId = recordId
         self.username = username
         self.followingLhUserRecordNames = followingLhUserRecordNames
         self.image = image
-        self.isVerified = isVerified
+        self.accountType = accountType
     }
 }
 
@@ -36,8 +41,9 @@ extension LhUser: CloudKitRecordable {
         guard let username = record[LhUserRecordKeys.username.rawValue] as? String else { return nil }
         let followingLhUserRecordNames = record[LhUserRecordKeys.followingLhUserRecordNames.rawValue] as? [String] ?? []
         let image = record[LhUserRecordKeys.image.rawValue] as? CKAsset
-        let isVerified = record[LhUserRecordKeys.isVerified.rawValue] as? Bool ?? false
-        self.init(recordId: record.recordID, username: username, followingLhUserRecordNames: followingLhUserRecordNames, image: image, isVerified: isVerified)
+        let accountTypeRaw = record[LhUserRecordKeys.accountType.rawValue] as? String
+        let accountType = accountTypeRaw.flatMap { AccountType(rawValue: $0) }
+        self.init(recordId: record.recordID, username: username, followingLhUserRecordNames: followingLhUserRecordNames, image: image, accountType: accountType)
     }
 
     public var record: CKRecord {
@@ -45,7 +51,7 @@ extension LhUser: CloudKitRecordable {
         record[LhUserRecordKeys.username.rawValue] = username
         record[LhUserRecordKeys.followingLhUserRecordNames.rawValue] = followingLhUserRecordNames
         record[LhUserRecordKeys.image.rawValue] = image
-        record[LhUserRecordKeys.isVerified.rawValue] = isVerified
+        record[LhUserRecordKeys.accountType.rawValue] = accountType?.rawValue
         return record
     }
 }
@@ -56,7 +62,7 @@ extension LhUser {
         username: "testUsername",
         followingLhUserRecordNames: [],
         image: nil,
-        isVerified: false
+        accountType: nil
     )
 }
 
@@ -66,7 +72,7 @@ public extension LhUser {
         case username
         case followingLhUserRecordNames
         case image
-        case isVerified
+        case accountType
     }
 }
 


### PR DESCRIPTION
## Summary
- replace `isVerified` flag on `LhUser` with optional `AccountType`
- save account type raw value in CloudKit records
- adjust UserManager for new initializer

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'CloudKit')*
