### PR TITLE
Add changeAccountType to UserManager

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -140,6 +140,18 @@ public struct UserManager: UserManageable {
         return try await updateSelfLhUser(with: newUser)
     }
 
+    public func changeAccountType(to accountType: LhUser.AccountType) async throws -> LhUser {
+        let (selfLhUser, _) = try await getSelfLhUser()
+        let newUser = LhUser(
+            username: selfLhUser.username,
+            followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
+            image: selfLhUser.image,
+            accountType: accountType
+        )
+
+        return try await updateSelfLhUser(with: newUser)
+    }
+
     public func isTaken(username: String) async throws -> Bool {
         let user = try await getLhUserByUsername(username)
         return user != nil

--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -45,6 +45,10 @@ public struct UserManagerMock: UserManageable {
         return .mock
     }
 
+    public func changeAccountType(to accountType: LhUser.AccountType) async throws -> LhUser {
+        return .mock
+    }
+
     public func isTaken(username: String) async throws -> Bool {
         return false
     }

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -17,6 +17,7 @@ public protocol UserManageable: Sendable {
     func addToSelfFollowing(_ followingRecordNames: [String]) async throws -> LhUser
     func changeUsername(to username: String) async throws -> LhUser
     func changeImage(to url: URL) async throws -> LhUser
+    func changeAccountType(to accountType: LhUser.AccountType) async throws -> LhUser
     func isTaken(username: String) async throws -> Bool
     func removeFromSelfFollowing(_ recordNames: [String]) async throws -> LhUser
     func getFollowers(for recordName: String) async throws -> ([LhUser], CKQueryOperation.Cursor?)


### PR DESCRIPTION
## Summary
- add `changeAccountType` to `UserManageable`
- implement `changeAccountType` in `UserManager` and `UserManagerMock`

## Testing
- `swift build` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_68425f44371483229109e07cea2e0a51