### PR TITLE
Add Identifiable conformance to LhUser

### DIFF
--- a/Sources/lhCloudKit/Models/LhUser.swift
+++ b/Sources/lhCloudKit/Models/LhUser.swift
@@ -76,5 +76,9 @@ public extension LhUser {
     }
 }
 
+extension LhUser: Identifiable {
+    public var id: String { username }
+}
+
 extension LhUser: Hashable {}
 


### PR DESCRIPTION
## Summary
- make `LhUser` conform to `Identifiable`

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6844c5b89a008322874e599924076edf