### PR TITLE
Add changeAccountVisibility helper

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -33,7 +33,13 @@ public struct UserManager: UserManageable {
     private func createLhUser() async throws -> (LhUser, CKRecord) {
         let (systemUser, systemUserRecord) = try await getSystemUser()
         guard systemUser.lhUserRecordName == nil else { throw CloudKitError.lhUserAlreadyExistsForSystemUser }
-        let user = LhUser(username: "user-\(Date.now.timeIntervalSince1970.description)-\(randomString(length: 8))", followingLhUserRecordNames: [], image: nil, accountType: nil)
+        let user = LhUser(
+            username: "user-\(Date.now.timeIntervalSince1970.description)-\(randomString(length: 8))",
+            followingLhUserRecordNames: [],
+            image: nil,
+            accountType: nil,
+            isPublicAccount: false
+        )
         let lhUserRecord = try await ck.save(record: user.record, db: .pubDb)
         systemUserRecord[User.UserRecordKeys.lhUserRecordName.rawValue] = lhUserRecord.recordID.recordName
         let _ = try await ck.save(record: systemUserRecord, db: .pubDb)
@@ -95,6 +101,7 @@ public struct UserManager: UserManageable {
         lhUserRecord[LhUser.LhUserRecordKeys.followingLhUserRecordNames.rawValue] = user.followingLhUserRecordNames
         lhUserRecord[LhUser.LhUserRecordKeys.image.rawValue] = user.image
         lhUserRecord[LhUser.LhUserRecordKeys.accountType.rawValue] = user.accountType?.rawValue
+        lhUserRecord[LhUser.LhUserRecordKeys.isPublicAccount.rawValue] = user.isPublicAccount
         let updatedUserRecord = try await ck.save(record: lhUserRecord, db: .pubDb)
         guard let newUser = LhUser(record: updatedUserRecord) else { throw CloudKitError.badRecordData }
         return newUser
@@ -111,7 +118,8 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: Array(newFollowing),
             image: selfLhUser.image,
-            accountType: selfLhUser.accountType
+            accountType: selfLhUser.accountType,
+            isPublicAccount: selfLhUser.isPublicAccount
         )
         return try await updateSelfLhUser(with: newUser)
     }
@@ -122,7 +130,8 @@ public struct UserManager: UserManageable {
             username: username,
             followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
             image: selfLhUser.image,
-            accountType: selfLhUser.accountType
+            accountType: selfLhUser.accountType,
+            isPublicAccount: selfLhUser.isPublicAccount
         )
 
         return try await updateSelfLhUser(with: newUser)
@@ -135,7 +144,8 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
             image: asset,
-            accountType: selfLhUser.accountType
+            accountType: selfLhUser.accountType,
+            isPublicAccount: selfLhUser.isPublicAccount
         )
 
         return try await updateSelfLhUser(with: newUser)
@@ -147,7 +157,21 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
             image: selfLhUser.image,
-            accountType: accountType
+            accountType: accountType,
+            isPublicAccount: selfLhUser.isPublicAccount
+        )
+
+        return try await updateSelfLhUser(with: newUser)
+    }
+
+    public func changeAccountVisibility(to isPublicAccount: Bool) async throws -> LhUser {
+        let (selfLhUser, _) = try await getSelfLhUser()
+        let newUser = LhUser(
+            username: selfLhUser.username,
+            followingLhUserRecordNames: selfLhUser.followingLhUserRecordNames,
+            image: selfLhUser.image,
+            accountType: selfLhUser.accountType,
+            isPublicAccount: isPublicAccount
         )
 
         return try await updateSelfLhUser(with: newUser)
@@ -166,7 +190,8 @@ public struct UserManager: UserManageable {
             username: selfLhUser.username,
             followingLhUserRecordNames: Array(newFollowing),
             image: selfLhUser.image,
-            accountType: selfLhUser.accountType
+            accountType: selfLhUser.accountType,
+            isPublicAccount: selfLhUser.isPublicAccount
         )
         return try await updateSelfLhUser(with: newUser)
     }

--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -49,6 +49,10 @@ public struct UserManagerMock: UserManageable {
         return .mock
     }
 
+    public func changeAccountVisibility(to isPublicAccount: Bool) async throws -> LhUser {
+        return .mock
+    }
+
     public func isTaken(username: String) async throws -> Bool {
         return false
     }

--- a/Sources/lhCloudKit/Models/LhUser.swift
+++ b/Sources/lhCloudKit/Models/LhUser.swift
@@ -13,6 +13,7 @@ public struct LhUser {
     public let followingLhUserRecordNames: [String]
     public let image: CKAsset?
     public let accountType: AccountType?
+    public let isPublicAccount: Bool?
 
     public enum AccountType: String {
         case verifiedUser
@@ -24,13 +25,15 @@ public struct LhUser {
         username: String,
         followingLhUserRecordNames: [String],
         image: CKAsset?,
-        accountType: AccountType?
+        accountType: AccountType?,
+        isPublicAccount: Bool?
     ) {
         self.recordId = recordId
         self.username = username
         self.followingLhUserRecordNames = followingLhUserRecordNames
         self.image = image
         self.accountType = accountType
+        self.isPublicAccount = isPublicAccount
     }
 }
 
@@ -43,7 +46,15 @@ extension LhUser: CloudKitRecordable {
         let image = record[LhUserRecordKeys.image.rawValue] as? CKAsset
         let accountTypeRaw = record[LhUserRecordKeys.accountType.rawValue] as? String
         let accountType = accountTypeRaw.flatMap { AccountType(rawValue: $0) }
-        self.init(recordId: record.recordID, username: username, followingLhUserRecordNames: followingLhUserRecordNames, image: image, accountType: accountType)
+        let isPublicAccount = record[LhUserRecordKeys.isPublicAccount.rawValue] as? Bool
+        self.init(
+            recordId: record.recordID,
+            username: username,
+            followingLhUserRecordNames: followingLhUserRecordNames,
+            image: image,
+            accountType: accountType,
+            isPublicAccount: isPublicAccount
+        )
     }
 
     public var record: CKRecord {
@@ -52,6 +63,7 @@ extension LhUser: CloudKitRecordable {
         record[LhUserRecordKeys.followingLhUserRecordNames.rawValue] = followingLhUserRecordNames
         record[LhUserRecordKeys.image.rawValue] = image
         record[LhUserRecordKeys.accountType.rawValue] = accountType?.rawValue
+        record[LhUserRecordKeys.isPublicAccount.rawValue] = isPublicAccount
         return record
     }
 }
@@ -62,7 +74,8 @@ extension LhUser {
         username: "testUsername",
         followingLhUserRecordNames: [],
         image: nil,
-        accountType: nil
+        accountType: nil,
+        isPublicAccount: nil
     )
 }
 
@@ -73,6 +86,7 @@ public extension LhUser {
         case followingLhUserRecordNames
         case image
         case accountType
+        case isPublicAccount
     }
 }
 

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -18,6 +18,7 @@ public protocol UserManageable: Sendable {
     func changeUsername(to username: String) async throws -> LhUser
     func changeImage(to url: URL) async throws -> LhUser
     func changeAccountType(to accountType: LhUser.AccountType) async throws -> LhUser
+    func changeAccountVisibility(to isPublicAccount: Bool) async throws -> LhUser
     func isTaken(username: String) async throws -> Bool
     func removeFromSelfFollowing(_ recordNames: [String]) async throws -> LhUser
     func getFollowers(for recordName: String) async throws -> ([LhUser], CKQueryOperation.Cursor?)


### PR DESCRIPTION
## Summary
- expose `changeAccountVisibility` on `UserManager` and `UserManageable`
- provide mock implementation
- default `recordId` parameter back to nil and drop explicit uses

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_68473bcc457c832280b6831bb6bcb7b3