### PR TITLE
Add LhUserFollower model and APIs

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -207,4 +207,21 @@ public struct UserManager: UserManageable {
         let followers = result.matchResults.compactMap { try? $0.1.get() }.compactMap { LhUser(record: $0) }
         return (followers, result.queryCursor)
     }
+
+    public func createUserFollower(_ userFollower: LhUserFollower) async throws -> LhUserFollower {
+        let record = userFollower.record
+        let savedRecord = try await ck.save(record: record, db: .pubDb)
+        guard let model = LhUserFollower(record: savedRecord) else { throw CloudKitError.badRecordData }
+        return model
+    }
+
+    public func deleteUserFollower(with id: CKRecord.ID) async throws {
+        let _ = try await ck.deleteRecord(withID: id, db: .pubDb)
+    }
+
+    public func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool {
+        let result = try await ck.records(for: .userFollower(.isFollowing(followerRecordName, followeeRecordName)), resultsLimit: 1, db: .pubDb)
+        let record = try? result.matchResults.first?.1.get()
+        return record != nil
+    }
 }

--- a/Sources/lhCloudKit/Models/LhUserFollower.swift
+++ b/Sources/lhCloudKit/Models/LhUserFollower.swift
@@ -1,0 +1,65 @@
+//
+//  LhUserFollower.swift
+//
+//  Created by Codex on 2024-08-05.
+//
+
+import CloudKit
+
+public struct LhUserFollower {
+    public let recordId: CKRecord.ID?
+    public let follower: String
+    public let followee: String
+    public let created: Int
+
+    public init(
+        recordId: CKRecord.ID? = nil,
+        follower: String,
+        followee: String,
+        created: Int
+    ) {
+        self.recordId = recordId
+        self.follower = follower
+        self.followee = followee
+        self.created = created
+    }
+}
+
+extension LhUserFollower: Sendable {}
+
+extension LhUserFollower: CloudKitRecordable {
+    public init?(record: CKRecord) {
+        guard
+            let follower = record[LhUserFollowerRecordKeys.follower.rawValue] as? String,
+            let followee = record[LhUserFollowerRecordKeys.followee.rawValue] as? String,
+            let created = record[LhUserFollowerRecordKeys.created.rawValue] as? Int
+        else { return nil }
+
+        self.init(recordId: record.recordID, follower: follower, followee: followee, created: created)
+    }
+
+    public var record: CKRecord {
+        let record = CKRecord(recordType: LhUserFollowerRecordKeys.type.rawValue)
+        record[LhUserFollowerRecordKeys.follower.rawValue] = follower
+        record[LhUserFollowerRecordKeys.followee.rawValue] = followee
+        record[LhUserFollowerRecordKeys.created.rawValue] = created
+        return record
+    }
+}
+
+extension LhUserFollower {
+    public static let mock: LhUserFollower = .init(follower: "follower", followee: "followee", created: 0)
+}
+
+public extension LhUserFollower {
+    enum LhUserFollowerRecordKeys: String {
+        case type = "LhUserFollower"
+        case follower
+        case followee
+        case created
+    }
+}
+
+extension LhUserFollower: Identifiable {
+    public var id: String { follower + followee + String(created) }
+}

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -23,4 +23,7 @@ public protocol UserManageable: Sendable {
     func removeFromSelfFollowing(_ recordNames: [String]) async throws -> LhUser
     func getFollowers(for recordName: String) async throws -> ([LhUser], CKQueryOperation.Cursor?)
     func continueUserFollowers(cursor: CKQueryOperation.Cursor) async throws -> ([LhUser], CKQueryOperation.Cursor?)
+    func createUserFollower(_ userFollower: LhUserFollower) async throws -> LhUserFollower
+    func deleteUserFollower(with id: CKRecord.ID) async throws
+    func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool
 }

--- a/Sources/lhCloudKit/Queries/Query.swift
+++ b/Sources/lhCloudKit/Queries/Query.swift
@@ -9,6 +9,7 @@ public enum Query {
     case heard(HeardQuery)
     case user(UserQuery)
     case venue(VenueQuery)
+    case userFollower(UserFollowerQuery)
 
     var query: CloudKitQuery {
         switch self {
@@ -18,6 +19,8 @@ public enum Query {
             userQuery.query
         case .venue(let venueQuery):
             venueQuery.query
+        case .userFollower(let followerQuery):
+            followerQuery.query
         }
     }
 }

--- a/Sources/lhCloudKit/Queries/UserFollowerQuery.swift
+++ b/Sources/lhCloudKit/Queries/UserFollowerQuery.swift
@@ -1,0 +1,29 @@
+//
+//  UserFollowerQuery.swift
+//
+//  Created by Codex on 2024-08-05.
+//
+
+import Foundation
+
+public extension Query {
+    enum UserFollowerQuery {
+        case isFollowing(String, String)
+
+        var query: CloudKitQuery {
+            switch self {
+            case .isFollowing(let follower, let followee):
+                return isFollowing(follower: follower, followee: followee)
+            }
+        }
+
+        private func isFollowing(follower: String, followee: String) -> CloudKitQuery {
+            return .init(
+                recordType: LhUserFollower.LhUserFollowerRecordKeys.type.rawValue,
+                sortDescriptorKey: LhUserFollower.LhUserFollowerRecordKeys.created.rawValue,
+                predicate: NSPredicate(format: "follower == %@ AND followee == %@", follower, followee),
+                database: .pubDb
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `LhUserFollower` CloudKit model
- support checking if a user is following another
- allow creating and deleting `LhUserFollower` records
- expose new APIs on `UserManager`

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6848e5cb51748322959dde846c3b9a35