### PR TITLE
Fix UserManagerMock protocol conformance

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -68,4 +68,14 @@ public struct UserManagerMock: UserManageable {
     public func continueUserFollowers(cursor: CKQueryOperation.Cursor) async throws -> ([LhUser], CKQueryOperation.Cursor?) {
         return ([.mock], nil)
     }
+
+    public func createUserFollower(_ userFollower: LhUserFollower) async throws -> LhUserFollower {
+        return .mock
+    }
+
+    public func deleteUserFollower(with id: CKRecord.ID) async throws { }
+
+    public func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool {
+        return false
+    }
 }


### PR DESCRIPTION
## Summary
- implement remaining UserManageable functions in `UserManagerMock`

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6848e8c27b788322bfb30213d4d6a025