### PR TITLE
Rename isFollowing to getFollowerLink

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -219,9 +219,9 @@ public struct UserManager: UserManageable {
         let _ = try await ck.deleteRecord(withID: id, db: .pubDb)
     }
 
-    public func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool {
+    public func getFollowerLink(for followerRecordName: String, followeeRecordName: String) async throws -> LhUserFollower? {
         let result = try await ck.records(for: .userFollower(.isFollowing(followerRecordName, followeeRecordName)), resultsLimit: 1, db: .pubDb)
-        let record = try? result.matchResults.first?.1.get()
-        return record != nil
+        guard let record = try? result.matchResults.first?.1.get() else { return nil }
+        return LhUserFollower(record: record)
     }
 }

--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -75,7 +75,7 @@ public struct UserManagerMock: UserManageable {
 
     public func deleteUserFollower(with id: CKRecord.ID) async throws { }
 
-    public func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool {
-        return false
+    public func getFollowerLink(for followerRecordName: String, followeeRecordName: String) async throws -> LhUserFollower? {
+        return nil
     }
 }

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -25,5 +25,5 @@ public protocol UserManageable: Sendable {
     func continueUserFollowers(cursor: CKQueryOperation.Cursor) async throws -> ([LhUser], CKQueryOperation.Cursor?)
     func createUserFollower(_ userFollower: LhUserFollower) async throws -> LhUserFollower
     func deleteUserFollower(with id: CKRecord.ID) async throws
-    func isFollowing(followerRecordName: String, followeeRecordName: String) async throws -> Bool
+    func getFollowerLink(for followerRecordName: String, followeeRecordName: String) async throws -> LhUserFollower?
 }


### PR DESCRIPTION
## Summary
- update UserManager to return a follower link model instead of bool
- update UserManageable protocol
- update UserManagerMock accordingly

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6848f818c3bc83228cb85e25f67410d7