### PR TITLE
Add pending follow request lookup

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager.swift
@@ -225,6 +225,14 @@ public struct UserManager: UserManageable {
         return LhUserFollower(record: record)
     }
 
+    public func isFollowRequestPending(for followeeRecordName: String) async throws -> LhUserFollowerRequest? {
+        let (selfUser, _) = try await getSelfLhUser()
+        guard let followerRecordName = selfUser.recordId?.recordName else { throw UserManagerError.selfUserNoRecordIdFound }
+        let result = try await ck.records(for: .userFollowerRequest(.isPending(followerRecordName, followeeRecordName)), resultsLimit: 1, db: .pubDb)
+        guard let record = try? result.matchResults.first?.1.get() else { return nil }
+        return LhUserFollowerRequest(record: record)
+    }
+
     public func createUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollowerRequest {
         let record = request.record
         let savedRecord = try await ck.save(record: record, db: .pubDb)

--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -79,6 +79,10 @@ public struct UserManagerMock: UserManageable {
         return nil
     }
 
+    public func isFollowRequestPending(for followeeRecordName: String) async throws -> LhUserFollowerRequest? {
+        return nil
+    }
+
     public func createUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollowerRequest {
         return .mock
     }

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -26,6 +26,7 @@ public protocol UserManageable: Sendable {
     func createUserFollower(_ userFollower: LhUserFollower) async throws -> LhUserFollower
     func deleteUserFollower(with id: CKRecord.ID) async throws
     func getFollowerLink(for followerRecordName: String, followeeRecordName: String) async throws -> LhUserFollower?
+    func isFollowRequestPending(for followeeRecordName: String) async throws -> LhUserFollowerRequest?
     func createUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollowerRequest
     func deleteUserFollowerRequest(with id: CKRecord.ID) async throws
     func acceptUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollower

--- a/Sources/lhCloudKit/Queries/Query.swift
+++ b/Sources/lhCloudKit/Queries/Query.swift
@@ -10,6 +10,7 @@ public enum Query {
     case user(UserQuery)
     case venue(VenueQuery)
     case userFollower(UserFollowerQuery)
+    case userFollowerRequest(UserFollowerRequestQuery)
 
     var query: CloudKitQuery {
         switch self {
@@ -21,6 +22,8 @@ public enum Query {
             venueQuery.query
         case .userFollower(let followerQuery):
             followerQuery.query
+        case .userFollowerRequest(let requestQuery):
+            requestQuery.query
         }
     }
 }

--- a/Sources/lhCloudKit/Queries/UserFollowerRequestQuery.swift
+++ b/Sources/lhCloudKit/Queries/UserFollowerRequestQuery.swift
@@ -1,0 +1,29 @@
+//
+//  UserFollowerRequestQuery.swift
+//
+//  Created by Codex on 2025-08-08.
+//
+
+import Foundation
+
+public extension Query {
+    enum UserFollowerRequestQuery {
+        case isPending(String, String)
+
+        var query: CloudKitQuery {
+            switch self {
+            case .isPending(let follower, let followee):
+                return isPending(follower: follower, followee: followee)
+            }
+        }
+
+        private func isPending(follower: String, followee: String) -> CloudKitQuery {
+            return .init(
+                recordType: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.type.rawValue,
+                sortDescriptorKey: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.created.rawValue,
+                predicate: NSPredicate(format: "follower == %@ AND followee == %@", follower, followee),
+                database: .pubDb
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the user manager protocol to check for pending follow requests
- implement pending follow request check in user manager and mock
- support the query for pending follower requests

## Testing
- `swift test -l` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6849ae1a44f48322a7cb1f90eeca5958