### PR TITLE
Add follower request retrieval functions

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManagerMock.swift
@@ -83,6 +83,14 @@ public struct UserManagerMock: UserManageable {
         return nil
     }
 
+    public func getAllFollowerRequests() async throws -> ([LhUserFollowerRequest], CKQueryOperation.Cursor?) {
+        return ([.mock], nil)
+    }
+
+    public func continueUserFollowerRequests(cursor: CKQueryOperation.Cursor) async throws -> ([LhUserFollowerRequest], CKQueryOperation.Cursor?) {
+        return ([.mock], nil)
+    }
+
     public func createUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollowerRequest {
         return .mock
     }

--- a/Sources/lhCloudKit/Protocols/UserManageable.swift
+++ b/Sources/lhCloudKit/Protocols/UserManageable.swift
@@ -27,6 +27,8 @@ public protocol UserManageable: Sendable {
     func deleteUserFollower(with id: CKRecord.ID) async throws
     func getFollowerLink(for followerRecordName: String, followeeRecordName: String) async throws -> LhUserFollower?
     func isFollowRequestPending(for followeeRecordName: String) async throws -> LhUserFollowerRequest?
+    func getAllFollowerRequests() async throws -> ([LhUserFollowerRequest], CKQueryOperation.Cursor?)
+    func continueUserFollowerRequests(cursor: CKQueryOperation.Cursor) async throws -> ([LhUserFollowerRequest], CKQueryOperation.Cursor?)
     func createUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollowerRequest
     func deleteUserFollowerRequest(with id: CKRecord.ID) async throws
     func acceptUserFollowerRequest(_ request: LhUserFollowerRequest) async throws -> LhUserFollower

--- a/Sources/lhCloudKit/Queries/UserFollowerRequestQuery.swift
+++ b/Sources/lhCloudKit/Queries/UserFollowerRequestQuery.swift
@@ -9,11 +9,14 @@ import Foundation
 public extension Query {
     enum UserFollowerRequestQuery {
         case isPending(String, String)
+        case getRequestsForFollowee(String)
 
         var query: CloudKitQuery {
             switch self {
             case .isPending(let follower, let followee):
                 return isPending(follower: follower, followee: followee)
+            case .getRequestsForFollowee(let followee):
+                return getAllRequests(for: followee)
             }
         }
 
@@ -22,6 +25,15 @@ public extension Query {
                 recordType: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.type.rawValue,
                 sortDescriptorKey: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.created.rawValue,
                 predicate: NSPredicate(format: "follower == %@ AND followee == %@", follower, followee),
+                database: .pubDb
+            )
+        }
+
+        private func getAllRequests(for followee: String) -> CloudKitQuery {
+            return .init(
+                recordType: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.type.rawValue,
+                sortDescriptorKey: LhUserFollowerRequest.LhUserFollowerRequestRecordKeys.created.rawValue,
+                predicate: NSPredicate(format: "followee == %@", followee),
                 database: .pubDb
             )
         }


### PR DESCRIPTION
## Summary
- extend query helper with getRequestsForFollowee
- add `getAllFollowerRequests` and continuation functions to `UserManager`
- update `UserManageable` and mocks for new methods

## Testing
- `swift test -v` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6849b187ed748322997599a45f5d73ec