### PR TITLE
Add Equatable conformance to follower request

### DIFF
--- a/Sources/lhCloudKit/Models/LhUserFollowerRequest.swift
+++ b/Sources/lhCloudKit/Models/LhUserFollowerRequest.swift
@@ -63,3 +63,12 @@ public extension LhUserFollowerRequest {
 extension LhUserFollowerRequest: Identifiable {
     public var id: String { follower + followee + String(created) }
 }
+
+extension LhUserFollowerRequest: Equatable {
+    public static func == (
+        lhs: LhUserFollowerRequest,
+        rhs: LhUserFollowerRequest
+    ) -> Bool {
+        lhs.id == rhs.id
+    }
+}


### PR DESCRIPTION
## Summary
- conform `LhUserFollowerRequest` to `Equatable`

## Testing
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_6849cc36e010832293d360f09ac9dbef