### PR TITLE
Add AuthManager protocol and mock

### DIFF
--- a/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
@@ -1,0 +1,20 @@
+//
+//  AuthManager.swift
+//
+//
+//  Created by Nicolas Le Gorrec on 8/8/24.
+//
+
+import Foundation
+
+public struct AuthManager: AuthManageable {
+    public init() { }
+
+    public func signInWithAppleIdToken(_ token: String) async throws {
+        // TODO: implement sign in with Apple ID token
+    }
+
+    public func signOut() async throws {
+        // TODO: implement sign out
+    }
+}

--- a/Sources/lhCloudKit/Manager/Auth/AuthManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManagerMock.swift
@@ -1,0 +1,16 @@
+//
+//  AuthManagerMock.swift
+//
+//
+//  Created by Nicolas Le Gorrec on 8/8/24.
+//
+
+import Foundation
+
+public struct AuthManagerMock: AuthManageable {
+    public init() {}
+
+    public func signInWithAppleIdToken(_ token: String) async throws { }
+
+    public func signOut() async throws { }
+}

--- a/Sources/lhCloudKit/Protocols/AuthManageable.swift
+++ b/Sources/lhCloudKit/Protocols/AuthManageable.swift
@@ -1,0 +1,13 @@
+//
+//  AuthManageable.swift
+//
+//
+//  Created by Nicolas Le Gorrec on 8/8/24.
+//
+
+import Foundation
+
+public protocol AuthManageable: Sendable {
+    func signInWithAppleIdToken(_ token: String) async throws
+    func signOut() async throws
+}


### PR DESCRIPTION
## Summary
- define `AuthManageable` protocol
- add stub `AuthManager` implementation
- add stub `AuthManagerMock`

## Testing
- `swift build` *(fails: no such module 'CloudKit')*
- `swift test` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_686b115d48c483228d0e3e7c565e2433