### PR TITLE
Add auth change event enum and stream

### DIFF
--- a/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
@@ -10,6 +10,13 @@ import Foundation
 public struct AuthManager: AuthManageable {
     public init() { }
 
+    public var authStateChanges: AsyncStream<(LhAuthChangeEvent, Bool)> {
+        AsyncStream { continuation in
+            // TODO: implement auth state change events
+            continuation.finish()
+        }
+    }
+
     public func signInWithAppleIdToken(_ token: String) async throws {
         // TODO: implement sign in with Apple ID token
     }

--- a/Sources/lhCloudKit/Manager/Auth/AuthManagerMock.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManagerMock.swift
@@ -10,6 +10,12 @@ import Foundation
 public struct AuthManagerMock: AuthManageable {
     public init() {}
 
+    public var authStateChanges: AsyncStream<(LhAuthChangeEvent, Bool)> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
     public func signInWithAppleIdToken(_ token: String) async throws { }
 
     public func signOut() async throws { }

--- a/Sources/lhCloudKit/Models/LhAuthChangeEvent.swift
+++ b/Sources/lhCloudKit/Models/LhAuthChangeEvent.swift
@@ -1,0 +1,19 @@
+//
+//  LhAuthChangeEvent.swift
+//
+//
+//  Created by Nicolas Le Gorrec on 2/4/24 (approx.).
+//
+
+import Foundation
+
+public enum LhAuthChangeEvent: String, Sendable {
+    case initialSession = "INITIAL_SESSION"
+    case passwordRecovery = "PASSWORD_RECOVERY"
+    case signedIn = "SIGNED_IN"
+    case signedOut = "SIGNED_OUT"
+    case tokenRefreshed = "TOKEN_REFRESHED"
+    case userUpdated = "USER_UPDATED"
+    case userDeleted = "USER_DELETED"
+    case mfaChallengeVerified = "MFA_CHALLENGE_VERIFIED"
+}

--- a/Sources/lhCloudKit/Protocols/AuthManageable.swift
+++ b/Sources/lhCloudKit/Protocols/AuthManageable.swift
@@ -10,4 +10,5 @@ import Foundation
 public protocol AuthManageable: Sendable {
     func signInWithAppleIdToken(_ token: String) async throws
     func signOut() async throws
+    var authStateChanges: AsyncStream<(LhAuthChangeEvent, Bool)> { get }
 }


### PR DESCRIPTION
## Summary
- introduce `LhAuthChangeEvent` enum listing possible auth events
- expose `authStateChanges` on `AuthManageable` protocol
- stub implementations of `authStateChanges` in `AuthManager` and `AuthManagerMock`

## Testing
- `swift test -l` *(fails: no such module 'CloudKit')*

------
https://chatgpt.com/codex/tasks/task_e_686b24c1be948322b9f017eca95ad42d