### PR TITLE
Add Supabase dependency and import

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,11 +14,17 @@ let package = Package(
             name: "lhCloudKit",
             targets: ["lhCloudKit"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/supabase-community/supabase-swift.git", exact: "2.29.3"),
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "lhCloudKit"),
+            name: "lhCloudKit",
+            dependencies: [
+                .product(name: "Supabase", package: "supabase-swift"),
+            ]),
         .testTarget(
             name: "lhCloudKitTests",
             dependencies: ["lhCloudKit"]

--- a/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Supabase
 
 public struct AuthManager: AuthManageable {
     public init() { }


### PR DESCRIPTION
## Summary
- add Supabase swift package to dependencies (exact version 2.29.3)
- expose the `Supabase` product to the `lhCloudKit` target
- import Supabase into `AuthManager`

## Testing
- `swift test --enable-code-coverage` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_686b2871f1e08322b669cf852041283b