### PR TITLE
Implement auth state change mapping

### DIFF
--- a/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
+++ b/Sources/lhCloudKit/Manager/Auth/AuthManager.swift
@@ -18,8 +18,14 @@ public struct AuthManager: AuthManageable {
 
     public var authStateChanges: AsyncStream<(LhAuthChangeEvent, Bool)> {
         AsyncStream { continuation in
-            // TODO: implement auth state change events
-            continuation.finish()
+            Task {
+                for await change in supabase.auth.authStateChanges {
+                    let event = LhAuthChangeEvent(rawValue: change.event.rawValue)
+                        ?? .signedOut
+                    let isSignedOut = change.session == nil
+                    continuation.yield((event, isSignedOut))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- wire up `AuthManager.authStateChanges` to the Supabase client's stream
- map Supabase events to `LhAuthChangeEvent` and expose a `Bool` indicating whether a session exists

## Testing
- `swift test -l` *(fails: Failed to clone repository https://github.com/supabase-community/supabase-swift.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_686b300cf2b4832280b517812b504926