### PR TITLE
Add Supabase follower request helpers

### DIFF
--- a/Sources/lhCloudKit/Manager/User/UserManager+Supabase.swift
+++ b/Sources/lhCloudKit/Manager/User/UserManager+Supabase.swift
@@ -22,3 +22,91 @@ extension UserManager {
             .value
     }
 }
+
+extension UserManager {
+    internal func isFollowRequestPending(
+        supabase: SupabaseClient,
+        followeeId: String
+    ) async throws -> LhUserFollowerRequest? {
+        let user = try await supabase.auth.session.user
+        let followerId = user.id.uuidString
+        let request: SupabaseLhUserFollowerRequest? = try await supabase
+            .from("lh_user_follower_requests")
+            .select()
+            .eq("follower", value: followerId)
+            .eq("followee", value: followeeId)
+            .maybeSingle()
+            .execute()
+            .value
+        return request?.model
+    }
+
+    internal func getAllFollowerRequests(
+        supabase: SupabaseClient,
+        limit: Int = 20,
+        offset: Int = 0
+    ) async throws -> [LhUserFollowerRequest] {
+        let user = try await supabase.auth.session.user
+        let followeeId = user.id.uuidString
+        let requests: [SupabaseLhUserFollowerRequest] = try await supabase
+            .from("lh_user_follower_requests")
+            .select()
+            .eq("followee", value: followeeId)
+            .order("created_at", ascending: false)
+            .range(from: offset, to: offset + limit - 1)
+            .execute()
+            .value
+        return requests.map { $0.model }
+    }
+
+    internal func createUserFollowerRequest(
+        supabase: SupabaseClient,
+        followeeId: String
+    ) async throws -> LhUserFollowerRequest {
+        let user = try await supabase.auth.session.user
+        let followerId = user.id.uuidString
+        let values: [String: Any] = [
+            "follower": followerId,
+            "followee": followeeId
+        ]
+        let request: SupabaseLhUserFollowerRequest = try await supabase
+            .from("lh_user_follower_requests")
+            .insert(values: values, returning: .representation)
+            .single()
+            .execute()
+            .value
+        return request.model
+    }
+
+    internal func deleteUserFollowerRequest(
+        supabase: SupabaseClient,
+        requestId: String
+    ) async throws {
+        _ = try await supabase
+            .from("lh_user_follower_requests")
+            .delete()
+            .eq("id", value: requestId)
+            .execute()
+    }
+
+    internal func acceptUserFollowerRequest(
+        supabase: SupabaseClient,
+        request: LhUserFollowerRequest
+    ) async throws -> LhUserFollower {
+        guard let requestId = request.recordId?.recordName else {
+            throw UserManagerError.noRecordIdFoundForUser
+        }
+        try await deleteUserFollowerRequest(supabase: supabase, requestId: requestId)
+        let values: [String: Any] = [
+            "follower": request.follower,
+            "followee": request.followee
+        ]
+        let follower: SupabaseLhUserFollower = try await supabase
+            .from("lh_user_followers")
+            .insert(values: values, returning: .representation)
+            .single()
+            .execute()
+            .value
+        return follower.model
+    }
+}

--- a/Sources/lhCloudKit/Models/SupabaseLhUserFollower.swift
+++ b/Sources/lhCloudKit/Models/SupabaseLhUserFollower.swift
@@ -1,0 +1,34 @@
+//
+//  SupabaseLhUserFollower.swift
+//  lhCloudKit
+//
+//  Created by Codex on 2025-08-05.
+//
+
+import CloudKit
+
+struct SupabaseLhUserFollower: Decodable {
+    let id: String
+    let follower: String
+    let followee: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case follower
+        case followee
+        case createdAt = "created_at"
+    }
+}
+
+extension SupabaseLhUserFollower {
+    var model: LhUserFollower {
+        let formatter = ISO8601DateFormatter()
+        let date = formatter.date(from: createdAt) ?? .now
+        return LhUserFollower(
+            follower: follower,
+            followee: followee,
+            created: Int(date.timeIntervalSince1970)
+        )
+    }
+}

--- a/Sources/lhCloudKit/Models/SupabaseLhUserFollowerRequest.swift
+++ b/Sources/lhCloudKit/Models/SupabaseLhUserFollowerRequest.swift
@@ -1,0 +1,34 @@
+//
+//  SupabaseLhUserFollowerRequest.swift
+//  lhCloudKit
+//
+//  Created by Codex on 2025-08-05.
+//
+
+import CloudKit
+
+struct SupabaseLhUserFollowerRequest: Decodable {
+    let id: String
+    let follower: String
+    let followee: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case follower
+        case followee
+        case createdAt = "created_at"
+    }
+}
+
+extension SupabaseLhUserFollowerRequest {
+    var model: LhUserFollowerRequest {
+        let formatter = ISO8601DateFormatter()
+        let date = formatter.date(from: createdAt) ?? .now
+        return LhUserFollowerRequest(
+            follower: follower,
+            followee: followee,
+            created: Int(date.timeIntervalSince1970)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add `SupabaseLhUserFollowerRequest` and `SupabaseLhUserFollower` models
- implement Supabase-based follower request APIs in `UserManager`
- omit CloudKit `recordId` when translating Supabase follower data

## Testing
- `swift test` *(fails: unable to fetch supabase-swift due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686dd69aad548322bc902167820ad884