### PR TITLE
Add Supabase SQL scripts for user tables

### DIFF
--- a/supabase/create_lh_user_follower_requests.sql
+++ b/supabase/create_lh_user_follower_requests.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS public.lh_user_follower_requests (
+  id uuid primary key default uuid_generate_v4(),
+  follower uuid not null references lh_users(id) on delete cascade,
+  followee uuid not null references lh_users(id) on delete cascade,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  constraint unique_follower_followee_pair unique (follower, followee)
+);
+
+-- Enable RLS
+alter table lh_user_follower_requests enable row level security;
+
+-- Policy: Allow delete if auth.uid() matches follower or followee
+create policy "Allow delete if user is follower or followee"
+on lh_user_follower_requests
+for delete
+using (
+  auth.uid() = follower OR auth.uid() = followee
+);
+
+-- Policy: Allow SELECT for users reading their own follow request
+create policy "Allow users to select their own profile"
+on lh_user_follower_requests
+for select
+using (
+  auth.uid() = follower OR auth.uid() = followee
+);
+
+-- Policy: Allow INSERT for users inserting their own follow request
+create policy "Allow insert if user is the follower"
+on lh_user_follower_requests
+for insert
+with check (
+  auth.uid() = follower
+);

--- a/supabase/create_lh_users_table_and_trigger.sql
+++ b/supabase/create_lh_users_table_and_trigger.sql
@@ -1,0 +1,69 @@
+-- Step 1: Create lh_users table
+CREATE TABLE IF NOT EXISTS public.lh_users (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  username TEXT UNIQUE NOT NULL CHECK (char_length(username) >= 3),
+
+  profile_image_url TEXT CHECK (
+    profile_image_url IS NULL OR profile_image_url ~ '^https?://'
+  ),
+
+  account_type TEXT CHECK (
+    account_type IN ('verifiedUser', 'verifiedArtist')
+  ),
+
+  is_public_account BOOLEAN NOT NULL DEFAULT false,
+
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Step 2: Create trigger function to auto-insert on auth.users signup
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  new_username TEXT;
+  suffix TEXT;
+BEGIN
+  LOOP
+    suffix := substring(md5(random()::text), 1, 16);
+    new_username := 'user_' || suffix;
+
+    BEGIN
+      INSERT INTO public.lh_users (id, username)
+      VALUES (NEW.id, new_username);
+      EXIT;
+    EXCEPTION WHEN unique_violation THEN
+      -- Retry on username collision
+    END;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Step 3: Create trigger on auth.users insert
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_user();
+
+-- Step 4: Enable Row-Level Security (RLS)
+ALTER TABLE public.lh_users ENABLE ROW LEVEL SECURITY;
+
+-- Step 5: Add policy - allow users to SELECT their own profile
+CREATE POLICY "Users can view their own profile"
+ON public.lh_users
+FOR SELECT
+USING (auth.uid() = id);
+
+-- Step 6: Add policy - allow users to UPDATE their own profile
+CREATE POLICY "Users can update their own profile"
+ON public.lh_users
+FOR UPDATE
+USING (auth.uid() = id);
+
+-- Step 7: Add policy - allow users to DELETE their own profile
+CREATE POLICY "Users can delete their own profile"
+ON public.lh_users
+FOR DELETE
+USING (auth.uid() = id);

--- a/supabase/drop_lh_user_follower_requests.sql
+++ b/supabase/drop_lh_user_follower_requests.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.lh_user_follower_requests CASCADE;

--- a/supabase/drop_lh_users_table_and_trigger.sql
+++ b/supabase/drop_lh_users_table_and_trigger.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS public.lh_users CASCADE;
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS public.handle_new_user;


### PR DESCRIPTION
## Summary
- add SQL script to drop and create `lh_user_follower_requests` with policies
- add SQL script to drop and create `lh_users` with trigger function and policies

## Testing
- `swift test` *(fails: unable to access dependency due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_689910b084b48322a8068dd5d414d00f